### PR TITLE
fix(react-separation): [FE] Dockerfile HEALTHCHECK URL을 127.0.0.1로 변경

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,4 +19,4 @@ COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=10s \
-  CMD wget --quiet --tries=1 --spider http://localhost/ || exit 1
+  CMD wget --quiet --tries=1 --spider http://127.0.0.1/ || exit 1


### PR DESCRIPTION
52 featreact initreact vite typescript 프로젝트 초기 세팅에서 추가적으로 작업할 내용이 생겨 작업 후 커밋.
해당 변경사항 검토 후 머지 바람.